### PR TITLE
Initial repo setup and initial features

### DIFF
--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -20,6 +20,7 @@ OC=${BTBX_BIN}/oc
 KC=${BTBX_BIN}/kubectl
 MBA=${BTBX_BIN}/micromamba
 VSCODE=${BTBX_BIN}/code
+K9S=${BTBX_BIN}/k9s
 
 #
 # Helper functions
@@ -195,6 +196,44 @@ ensure_cli_micromamba() {
   mkdir -p ${BTBX_BIN}
   mv ${temp_dir}/bin/micromamba ${BTBX_BIN}/
   chmod 700 ${BTBX_BIN}/micromamba
+  rm -rf ${temp_dir}
+  return 0
+}
+
+ensure_cli_k9s() {
+  # Ensure k9s
+
+  K9S_VER=v0.30.5
+
+  if [[ ! -z ${1} ]]; then
+    BTBX_BIN=$1
+  fi
+  if [[ -e ${BTBX_BIN}/k9s ]]; then
+    return 0
+  fi
+
+  # Download vscode CLI
+  temp_dir=$(mktemp -d)
+  mkdir -p ${temp_dir}
+
+  case ${OS_ARCH} in
+  Darwin-x86_64)
+    curl -LS https://github.com/derailed/k9s/releases/download/${K9S_VER}/k9s_Darwin_amd64.tar.gz | tar -xvj -C ${temp_dir} k9s
+    ;;
+  Darwin-arm64)
+    curl -Ls https://github.com/derailed/k9s/releases/download/${K9S_VER}/k9s_Darwin_arm64.tar.gz | tar -xvj -C ${temp_dir} k9s
+    ;;
+  GNULinux-x86_64)
+    curl -Ls https://github.com/derailed/k9s/releases/download/${K9S_VER}/k9s_Linux_amd64.tar.gz | tar -xvj -C ${temp_dir} k9s
+    ;;
+  GNULinux-arm64)
+    curl -Ls https://github.com/derailed/k9s/releases/download/${K9S_VER}/k9s_Linux_arm64.tar.gz | tar -xvj -C ${temp_dir} k9s
+    ;;
+  esac
+
+  mkdir -p ${BTBX_BIN}
+  mv ${temp_dir}/k9s ${BTBX_BIN}/
+  chmod 700 ${BTBX_BIN}/k9s
   rm -rf ${temp_dir}
   return 0
 }

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -22,6 +22,7 @@ KC=${BTBX_BIN}/kubectl
 MBA=${BTBX_BIN}/micromamba
 VSCODE=${BTBX_BIN}/code
 K9S=${BTBX_BIN}/k9s
+DVC=${BTBX_BIN}/dvc
 
 #
 # Helper functions
@@ -241,7 +242,7 @@ ensure_cli_k9s() {
 
 ensure_cli_mambaenv() {
   # Ensure mamba environment with python
-  PYTHON3_VER=3.9.6
+  PYTHON3_VER=3.11.7
 
   if [[ ! -z ${1} ]]; then
     BTBX_MAMBA=$1
@@ -257,6 +258,25 @@ ensure_cli_mambaenv() {
   ${MBA} create -p ${BTBX_MAMBA} -y -c conda-forge \
     python=${PYTHON3_VER} \
     pipx
+  return 0
+}
+
+ensure_cli_dvc() {
+  # Install dvc on mamba
+
+  DVC_VER=3.37.0
+
+  if [[ -e ${BTBX_BIN}/dvc ]]; then
+    return 0
+  fi
+  ensure_cli_mambaenv $1
+
+  # DVC will be installed using pipx
+  export PIPX_HOME=${BTBX_BASE}
+  export PIPX_BIN_DIR=${BTBX_BIN}
+  local PIPX=${BTBX_MAMBA}/bin/pipx
+
+  ${PIPX} install dvc==${DVC_VER}
   return 0
 }
 

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -6,19 +6,20 @@
 
 # Get the relative home of this file
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	export FILE_HOME=$(realpath $(dirname $0))
+	export BTBX_HOME=$(realpath $(dirname $0))
 else
-	export FILE_HOME=$(realpath $(dirname ${BASH_SOURCE}))
+	export BTBX_HOME=$(realpath $(dirname ${BASH_SOURCE}))
 fi
 
 OS_ARCH=$(uname -o | tr -d '/')-$(uname -m)
 
 # File destination can be configured from the caller
-FILE_DST=${FILE_DST:-${FILE_HOME}/.${OS_ARCH}}
-OC=${FILE_DST}/oc
-KC=${FILE_DST}/kubectl
-MBA=${FILE_DST}/micromamba
-VSCODE=${FILE_DST}/code
+BTBX_BASE=${BTBX_BASE:-${BTBX_HOME}/.${OS_ARCH}}
+BTBX_BIN=${BTBX_BIN:-${BTBX_BASE}/bin}
+OC=${BTBX_BIN}/oc
+KC=${BTBX_BIN}/kubectl
+MBA=${BTBX_BIN}/micromamba
+VSCODE=${BTBX_BIN}/code
 
 #
 # Helper functions
@@ -90,9 +91,9 @@ function ensure_cli_openshift() {
   OCP_VER=4.12.9
   OCP_BASE=https://mirror.openshift.com/pub/openshift-v4/clients/ocp
   if [[ ! -z ${1} ]]; then
-    FILE_DST=$1
+    BTBX_BIN=$1
   fi
-  if [[ -e ${FILE_DST}/oc && -e ${FILE_DST}/kubectl ]]; then
+  if [[ -e ${BTBX_BIN}/oc && -e ${BTBX_BIN}/kubectl ]]; then
     return 0
   fi
 
@@ -119,11 +120,11 @@ function ensure_cli_openshift() {
     mkdir -p "$temp_dir"
     curl -o "$temp_dir/oc.tar.gz" ${URL} &> /dev/null
     tar xzf "$temp_dir/oc.tar.gz" -C "$temp_dir"
-    mkdir -p ${FILE_DST}
-    mv "$temp_dir/oc" ${FILE_DST}/
-    mv "$temp_dir/kubectl" ${FILE_DST}/
-    chmod 700 ${FILE_DST}/oc
-    chmod 700 ${FILE_DST}/kubectl
+    mkdir -p ${BTBX_BIN}
+    mv "$temp_dir/oc" ${BTBX_BIN}/
+    mv "$temp_dir/kubectl" ${BTBX_BIN}/
+    chmod 700 ${BTBX_BIN}/oc
+    chmod 700 ${BTBX_BIN}/kubectl
     rm -rf "$temp_dir"
   fi
   return 0
@@ -131,9 +132,9 @@ function ensure_cli_openshift() {
 
 ensure_cli_vscode() {
   if [[ ! -z ${1} ]]; then
-    FILE_DST=$1
+    BTBX_BIN=$1
   fi
-  if [[ -e ${FILE_DST}/code ]]; then
+  if [[ -e ${BTBX_BIN}/code ]]; then
     return 0
   fi
 
@@ -158,9 +159,9 @@ ensure_cli_vscode() {
     mkdir -p "$temp_dir"
     curl -Lk ${URL} --output ${temp_dir}/vscode_cli.tar.gz &>/dev/null
     tar xzf "$temp_dir/vscode_cli.tar.gz" -C "$temp_dir"
-    mkdir -p ${FILE_DST}
-    mv "$temp_dir/code" ${FILE_DST}/
-    chmod 700 ${FILE_DST}/code
+    mkdir -p ${BTBX_BIN}
+    mv "$temp_dir/code" ${BTBX_BIN}/
+    chmod 700 ${BTBX_BIN}/code
     rm -rf "$temp_dir"
   fi
   return 0
@@ -168,9 +169,9 @@ ensure_cli_vscode() {
 
 ensure_cli_micromamba() {
   if [[ ! -z ${1} ]]; then
-    FILE_DST=$1
+    BTBX_BIN=$1
   fi
-  if [[ -e ${FILE_DST}/micromamba ]]; then
+  if [[ -e ${BTBX_BIN}/micromamba ]]; then
     return 0
   fi
 
@@ -191,9 +192,9 @@ ensure_cli_micromamba() {
     curl -Ls https://micro.mamba.pm/api/micromamba/linux-aarch64/latest | tar -xvj -C ${temp_dir} bin/micromamba
     ;;
   esac
-  mkdir -p ${FILE_DST}
-  mv ${temp_dir}/bin/micromamba ${FILE_DST}/
-  chmod 700 ${FILE_DST}/micromamba
+  mkdir -p ${BTBX_BIN}
+  mv ${temp_dir}/bin/micromamba ${BTBX_BIN}/
+  chmod 700 ${BTBX_BIN}/micromamba
   rm -rf ${temp_dir}
   return 0
 }

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -17,11 +17,27 @@ OS_ARCH=$(uname -o | tr -d '/')-$(uname -m)
 BTBX_BASE=${BTBX_BASE:-${BTBX_HOME}/.${OS_ARCH}}
 BTBX_BIN=${BTBX_BIN:-${BTBX_BASE}/bin}
 BTBX_MAMBA=${BTBX_MAMBA:-${BTBX_BASE}/opt/mamba}
+
+# K8s CLI
+OCP_VER=${OCP_VER:-4.12.9}
 OC=${BTBX_BIN}/oc
 KC=${BTBX_BIN}/kubectl
+
+# Mamba
 MBA=${BTBX_BIN}/micromamba
+
+# VSCode
 VSCODE=${BTBX_BIN}/code
+
+#K9s
+K9S_VER=${K9S_VER:-v0.30.5}
 K9S=${BTBX_BIN}/k9s
+
+# Python3
+PYTHON3_VER=${PYTHON3_VER:-3.11.7}
+
+# DVC
+DVC_VER=${DVC_VER:-3.37.0}
 DVC=${BTBX_BIN}/dvc
 
 #
@@ -91,7 +107,6 @@ k8s_auth_ensure() {
 
 function ensure_cli_openshift() {
   # Openshift client source
-  OCP_VER=4.12.9
   OCP_BASE=https://mirror.openshift.com/pub/openshift-v4/clients/ocp
   if [[ ! -z ${1} ]]; then
     BTBX_BIN=$1
@@ -205,8 +220,6 @@ ensure_cli_micromamba() {
 ensure_cli_k9s() {
   # Ensure k9s
 
-  K9S_VER=v0.30.5
-
   if [[ ! -z ${1} ]]; then
     BTBX_BIN=$1
   fi
@@ -242,8 +255,6 @@ ensure_cli_k9s() {
 
 ensure_cli_mambaenv() {
   # Ensure mamba environment with python
-  PYTHON3_VER=3.11.7
-
   if [[ ! -z ${1} ]]; then
     BTBX_MAMBA=$1
   fi
@@ -267,9 +278,6 @@ ensure_cli_mambaenv() {
 
 ensure_cli_dvc() {
   # Install dvc on mamba
-
-  DVC_VER=3.37.0
-
   if [[ -e ${BTBX_BIN}/dvc ]]; then
     return 0
   fi

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -40,6 +40,10 @@ PYTHON3_VER=${PYTHON3_VER:-3.11.7}
 DVC_VER=${DVC_VER:-3.37.0}
 DVC=${BTBX_BIN}/dvc
 
+# mlflow
+MLFLOW_VER=${MLFLOW_VER:-2.9.2}
+MLFLOW=${BTBX_BIN}/mlflow
+
 # yq
 YQ_VER=${YQ_VER:-v4.40.5}
 YQ=${BTBX_BIN}/yq
@@ -293,6 +297,22 @@ ensure_cli_dvc() {
   local PIPX=${BTBX_MAMBA}/bin/pipx
 
   ${PIPX} install dvc[all]==${DVC_VER}
+  return 0
+}
+
+ensure_cli_mlflow() {
+  # Install dvc on mamba
+  if [[ -e ${BTBX_BIN}/mlflow ]]; then
+    return 0
+  fi
+  ensure_cli_mambaenv $1
+
+  # DVC will be installed using pipx
+  export PIPX_HOME=${BTBX_BASE}
+  export PIPX_BIN_DIR=${BTBX_BIN}
+  local PIPX=${BTBX_MAMBA}/bin/pipx
+
+  ${PIPX} install mlflow==${MLFLOW_VER}
   return 0
 }
 

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -253,6 +253,10 @@ ensure_cli_mambaenv() {
     && -e ${BTBX_MAMBA}/bin/pipx ]]; then
     return 0
   fi
+
+  # Ensure dependencies
+  ensure_cli_micromamba
+
   # Setup a mamba environment with python and pipx as a base
   mkdir -p $(dirname ${BTBX_MAMBA})
   ${MBA} create -p ${BTBX_MAMBA} -y -c conda-forge \

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -280,7 +280,7 @@ ensure_cli_dvc() {
   export PIPX_BIN_DIR=${BTBX_BIN}
   local PIPX=${BTBX_MAMBA}/bin/pipx
 
-  ${PIPX} install dvc==${DVC_VER}
+  ${PIPX} install dvc[all]==${DVC_VER}
   return 0
 }
 

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -40,6 +40,10 @@ PYTHON3_VER=${PYTHON3_VER:-3.11.7}
 DVC_VER=${DVC_VER:-3.37.0}
 DVC=${BTBX_BIN}/dvc
 
+# yq
+YQ_VER=${YQ_VER:-v4.40.5}
+YQ=${BTBX_BIN}/yq
+
 #
 # Helper functions
 #
@@ -289,6 +293,44 @@ ensure_cli_dvc() {
   local PIPX=${BTBX_MAMBA}/bin/pipx
 
   ${PIPX} install dvc[all]==${DVC_VER}
+  return 0
+}
+
+ensure_cli_yq() {
+  # Ensure yq the yaml parser
+
+  if [[ ! -z ${1} ]]; then
+    BTBX_BIN=$1
+  fi
+  if [[ -e ${BTBX_BIN}/yq ]]; then
+    return 0
+  fi
+
+  # Download vscode CLI
+  temp_dir=$(mktemp -d)
+  mkdir -p ${temp_dir}
+  mkdir -p ${BTBX_BIN}
+
+  case ${OS_ARCH} in
+  Darwin-x86_64)
+    curl -LS https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_darwin_amd64.tar.gz | tar -xvj -C ${temp_dir} yq_darwin_amd64
+    cp ${temp_dir}/yq_darwin_amd64 ${BTBX_BIN}/yq
+    ;;
+  Darwin-arm64)
+    curl -LS https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_darwin_arm64.tar.gz | tar -xvj -C ${temp_dir} yq_darwin_arm64
+    cp ${temp_dir}/yq_darwin_arm64 ${BTBX_BIN}/yq
+    ;;
+  GNULinux-x86_64)
+    curl -LS https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_linux_amd64.tar.gz | tar -xvj -C ${temp_dir} yq_linux_amd64
+    cp ${temp_dir}/yq_linux_amd64 ${BTBX_BIN}/yq
+    ;;
+  GNULinux-arm64)
+    curl -LS https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_linux_arm64.tar.gz | tar -xvj -C ${temp_dir} yq_linux_arm64
+    cp ${temp_dir}/yq_linux_arm64 ${BTBX_BIN}/yq
+    ;;
+  esac
+  chmod 700 ${BTBX_BIN}/yq
+  rm -rf ${temp_dir}
   return 0
 }
 

--- a/lib/btbx.sh
+++ b/lib/btbx.sh
@@ -16,6 +16,7 @@ OS_ARCH=$(uname -o | tr -d '/')-$(uname -m)
 # File destination can be configured from the caller
 BTBX_BASE=${BTBX_BASE:-${BTBX_HOME}/.${OS_ARCH}}
 BTBX_BIN=${BTBX_BIN:-${BTBX_BASE}/bin}
+BTBX_MAMBA=${BTBX_MAMBA:-${BTBX_BASE}/opt/mamba}
 OC=${BTBX_BIN}/oc
 KC=${BTBX_BIN}/kubectl
 MBA=${BTBX_BIN}/micromamba
@@ -235,6 +236,27 @@ ensure_cli_k9s() {
   mv ${temp_dir}/k9s ${BTBX_BIN}/
   chmod 700 ${BTBX_BIN}/k9s
   rm -rf ${temp_dir}
+  return 0
+}
+
+ensure_cli_mambaenv() {
+  # Ensure mamba environment with python
+  PYTHON3_VER=3.9.6
+
+  if [[ ! -z ${1} ]]; then
+    BTBX_MAMBA=$1
+  fi
+  if [[ -e ${BTBX_MAMBA} \
+    && -e ${BTBX_MAMBA}/bin/python3 \
+    && -e ${BTBX_MAMBA}/bin/pip3 \
+    && -e ${BTBX_MAMBA}/bin/pipx ]]; then
+    return 0
+  fi
+  # Setup a mamba environment with python and pipx as a base
+  mkdir -p $(dirname ${BTBX_MAMBA})
+  ${MBA} create -p ${BTBX_MAMBA} -y -c conda-forge \
+    python=${PYTHON3_VER} \
+    pipx
   return 0
 }
 

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -46,6 +46,7 @@ teardown() {
     # Artificially create a safe environment
     unset BTBX_BASE
     unset BTBX_BIN
+    unset BTBX_MAMBA
 
     # Setup a new base
     BTBX_BASE=${TMP_DIR}
@@ -53,6 +54,7 @@ teardown() {
 
     # Then we should have a series of variables automatically set
     assert_equal ${BTBX_BIN} ${TMP_DIR}/bin
+    assert_equal ${BTBX_MAMBA} ${TMP_DIR}/opt/mamba
 }
 
 #
@@ -86,6 +88,20 @@ teardown() {
     assert_exist ${K9S}
     run ${K9S} --help
     assert_output -p 'K9s'
+}
+
+@test "ensure_cli - mamba environment for btbx can be created" {
+    ensure_cli_mambaenv
+    assert_equal ${BTBX_MAMBA} ${BTBX_BASE}/opt/mamba
+    assert_exist ${BTBX_MAMBA}
+    assert_exist ${BTBX_BASE}/opt/mamba
+    assert_exist ${BTBX_BASE}/opt/mamba/bin/python3
+    assert_exist ${BTBX_BASE}/opt/mamba/bin/pip3
+    assert_exist ${BTBX_BASE}/opt/mamba/bin/pipx
+
+    ${BTBX_BASE}/opt/mamba/bin/python3 --version
+    ${BTBX_BASE}/opt/mamba/bin/pip3 --version
+    ${BTBX_BASE}/opt/mamba/bin/pipx --version
 }
 
 #

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -8,12 +8,12 @@ setup() {
     load ${ROOT}/tests/lib/bats-detik/lib/detik
 
     # Load the library file
-    FILE_DST=${ROOT}/.tmp/bin
+    BTBX_BASE=${ROOT}/.tmp
     load ${ROOT}/lib/btbx.sh
 
     # Test what we need
-    assert_exist ${FILE_DST}/oc
-    assert_exist ${FILE_DST}/kubectl
+    assert_exist ${BTBX_BIN}/oc
+    assert_exist ${BTBX_BIN}/kubectl
     assert_exist ${OC}
     assert_exist ${KC}
 
@@ -34,9 +34,25 @@ teardown() {
     temp_del ${TMP_DIR}
 }
 
-@test "btbx.sh can be loaded properly" {
-    assert_equal ${FILE_HOME} $(realpath ${ROOT}/lib)
-    assert_exist ${FILE_HOME}/btbx.sh
+@test "btbx.sh - can be loaded properly" {
+    assert_equal ${BTBX_HOME} $(realpath ${ROOT}/lib)
+    assert_exist ${BTBX_HOME}/btbx.sh
+}
+
+@test "btbx.sh - environment variable propagation" {
+    # Test if btbx.sh can build the environment variables
+    # as expected if we have a clean environment
+
+    # Artificially create a safe environment
+    unset BTBX_BASE
+    unset BTBX_BIN
+
+    # Setup a new base
+    BTBX_BASE=${TMP_DIR}
+    . ${BTBX_HOME}/btbx.sh
+
+    # Then we should have a series of variables automatically set
+    assert_equal ${BTBX_BIN} ${TMP_DIR}/bin
 }
 
 #

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -110,6 +110,12 @@ teardown() {
     ${DVC} --version
 }
 
+@test "ensure_cli - mlflow - experiment and model tracker" {
+    ensure_cli_mlflow
+    assert_exist ${BTBX_BIN}/mlflow
+    ${MLFLOW} --version
+}
+
 @test "ensure_cli - yq the yaml parsing tool" {
     ensure_cli_yq
     assert_exist ${BTBX_BIN}/yq

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -81,6 +81,13 @@ teardown() {
     ${MBA}
 }
 
+@test "ensure_cli - k9s cli can be downloaded an run properly" {
+    ensure_cli_k9s
+    assert_exist ${K9S}
+    run ${K9S} --help
+    assert_output -p 'K9s'
+}
+
 #
 # adhoc_pod on k8s
 #

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -43,26 +43,26 @@ teardown() {
 # Downloaders for external binaries
 #
 
-@test "ensure_cli - openshift client can be downloaded and run properly" {
-    ensure_cli_openshift ${TMP_DIR}
+@test "ensure_cli - openshift clients can be downloaded and run properly" {
+    ensure_cli_openshift
     # Openshift CLI
-    assert_exist ${TMP_DIR}/oc
-    ${TMP_DIR}/oc
+    assert_exist ${OC}
+    ${OC}
     # Kubectl CLI
-    assert_exist ${TMP_DIR}/kubectl
-    ${TMP_DIR}/kubectl
+    assert_exist ${KC}
+    ${KC}
 }
 
-@test "ensure_cli - vscode can be downloaded an run properly" {
-    ensure_cli_vscode ${TMP_DIR}
-    assert_exist ${TMP_DIR}/code
-    ${TMP_DIR}/code --help
+@test "ensure_cli - vscode cli can be downloaded an run properly" {
+    ensure_cli_vscode
+    assert_exist ${VSCODE}
+    ${VSCODE} --help
 }
 
-@test "ensure_cli - micromamba can be downloaded an run properly" {
-    ensure_cli_micromamba ${TMP_DIR}
-    assert_exist ${TMP_DIR}/micromamba
-    ${TMP_DIR}/micromamba
+@test "ensure_cli - micromamba cli can be downloaded an run properly" {
+    ensure_cli_micromamba
+    assert_exist ${MBA}
+    ${MBA}
 }
 
 #

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -110,6 +110,12 @@ teardown() {
     ${DVC} --version
 }
 
+@test "ensure_cli - yq the yaml parsing tool" {
+    ensure_cli_yq
+    assert_exist ${BTBX_BIN}/yq
+    ${YQ} --version
+}
+
 #
 # adhoc_pod on k8s
 #

--- a/tests/btbx.sh.bats
+++ b/tests/btbx.sh.bats
@@ -104,6 +104,12 @@ teardown() {
     ${BTBX_BASE}/opt/mamba/bin/pipx --version
 }
 
+@test "ensure_cli - dvc - data version control" {
+    ensure_cli_dvc
+    assert_exist ${BTBX_BIN}/dvc
+    ${DVC} --version
+}
+
 #
 # adhoc_pod on k8s
 #

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -9,13 +9,13 @@ setup_suite() {
     load ${ROOT}/tests/lib/bats-file/load
 
     # Load the library itself
-    export FILE_DST=${ROOT}/.tmp/bin
+    export BTBX_BASE=${ROOT}/.tmp
     load ${ROOT}/lib/btbx.sh
 
     # Ensure the command line utilities
-    ensure_cli_openshift ${FILE_DST}
-    assert_exist ${FILE_DST}/oc
-    assert_exist ${FILE_DST}/kubectl
+    ensure_cli_openshift ${BTBX_BIN}
+    assert_exist ${BTBX_BIN}/oc
+    assert_exist ${BTBX_BIN}/kubectl
     assert_exist ${OC}
     assert_exist ${KC}
 


### PR DESCRIPTION
Changes for setting up the repository.
- cleanup of btbx and its relationship with the tests
- cleanup of handling the `BTBX_***` variables
- cleanup of the initial form of ensure_cli at its behavior

Initial features related to the `ensure_cli_***` section on top of adding k9s
- Add k9s support
- Add yq support
- Add mamba environment for python and pipx
- Add dvc support
- Add MLflow support